### PR TITLE
Fix cloud-init on VMWare

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -104,7 +104,7 @@ def set_config_ovf(config, hostname, metadata):
     APIPORT = metadata['APIPORT']
     APIDEBUG = metadata['APIDEBUG']
 
-    if ip_0 != '' and mask_0 != '' and gateway != '': 
+    if ip_0 and ip_0 != 'null' and mask_0 and mask_0 != 'null' and gateway and gateway != 'null': 
         cidr = str(IPv4Network('0.0.0.0/' + mask_0).prefixlen) 
         ipcidr = ip_0 + '/' + cidr
 


### PR DESCRIPTION
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/stages.py", line 812, in _run_modules
    freq=freq)
  File "/usr/lib/python3/dist-packages/cloudinit/cloud.py", line 54, in run
    return self._runners.run(name, functor, args, freq, clear_on_fail)
  File "/usr/lib/python3/dist-packages/cloudinit/helpers.py", line 187, in run
    results = functor(*args)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_vyos.py", line 274, in handle
    set_config_ovf(config, hostname, metadata)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_vyos.py", line 105, in set_config_ovf
    cidr = str(IPv4Network('0.0.0.0/' + mask_0).prefixlen)
  File "/usr/lib/python3.4/ipaddress.py", line 1515, in __init__
    self._prefixlen = self._prefix_from_ip_string(addr[1])
  File "/usr/lib/python3.4/ipaddress.py", line 539, in _prefix_from_ip_string
    self._report_invalid_netmask(ip_str)
  File "/usr/lib/python3.4/ipaddress.py", line 497, in _report_invalid_netmask
    raise NetmaskValueError(msg) from None
ipaddress.NetmaskValueError: 'null' is not a valid netmask