### PR TITLE
cc_vyos: T2117: OVF datasource cleanup

### DIFF
--- a/cloudinit/sources/DataSourceOVF.py
+++ b/cloudinit/sources/DataSourceOVF.py
@@ -436,8 +436,7 @@ def read_ovf_environment(contents):
     cfg = {}
     ud = None
     cfg_props = ['password']
-    md_props = ['seedfrom', 'local-hostname', 'public-keys', 'instance-id',
-                'ip0', 'netmask0', 'gateway', 'DNS', 'NTP', 'APIKEY' ,'APIPORT', 'APIDEBUG']
+    md_props = ['seedfrom', 'local-hostname', 'public-keys', 'instance-id']
     for (prop, val) in props.items():
         if prop == 'hostname':
             prop = "local-hostname"


### PR DESCRIPTION
The `DataSourceOVF.py` file was cleaned up from VyOS-specific changes.
Also was changed related functionality in the `cc_vyos.py`:

  - in addition to limited metadata provided by Cloud-init, the function `get_properties` from the `DataSourceOVF.py` used to get unfiltered values from an OVF environment;
  - `set_tag` for the `interfaces ethernet` node was moved from multiple places to the `set_ipaddress` function;
  - multiple checks for 'null' value in OVF were replaced with the iteration via all values and replacing `null` with `None`. This allows using easier logic during values check;
  - simplified conversion of the values from OVF to an IP address;
  - added logging for all actions in the `set_config_ovf` function.