### PR TITLE
T2117: Cleaned up systemd service for cloud-config

### DIFF
--- a/systemd/cloud-config.service.tmpl
+++ b/systemd/cloud-config.service.tmpl
@@ -1,7 +1,6 @@
 ## template:jinja
 [Unit]
 Description=Apply the settings specified in cloud-config
-Before=vyos-router.service
 After=network-online.target cloud-config.target
 After=snapd.seeded.service
 Wants=network-online.target cloud-config.target


### PR DESCRIPTION
The startup order control was moved from the `cloud-config.service.tmpl` template to the `vyos-router.service` in the https://github.com/vyos/vyatta-cfg/commit/94f7abdf748c24b70c4741417c74147e52689da3