### PR TITLE
dhclient: T3309: Removed dhclient from datasources

### DIFF
--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -36,14 +36,14 @@ ENI_HEADER = """# This file is generated from information provided by
 # network: {config: disabled}
 """
 
-NETWORK_CONF_FN = "/etc/network/interfaces.d/50-cloud-init.cfg"
+NETWORK_CONF_FN = "/etc/network/interfaces.d/50-cloud-init"
 LOCALE_CONF_FN = "/etc/default/locale"
 
 
 class Distro(distros.Distro):
     hostname_conf_fn = "/etc/hostname"
     network_conf_fn = {
-        "eni": "/etc/network/interfaces.d/50-cloud-init.cfg",
+        "eni": "/etc/network/interfaces.d/50-cloud-init",
         "netplan": "/etc/netplan/50-cloud-init.yaml"
     }
     renderer_configs = {

--- a/cloudinit/distros/ubuntu.py
+++ b/cloudinit/distros/ubuntu.py
@@ -21,6 +21,21 @@ LOG = logging.getLogger(__name__)
 
 class Distro(debian.Distro):
 
+    def __init__(self, name, cfg, paths):
+        super(Distro, self).__init__(name, cfg, paths)
+        # Ubuntu specific network cfg locations
+        self.network_conf_fn = {
+            "eni": "/etc/network/interfaces.d/50-cloud-init.cfg",
+            "netplan": "/etc/netplan/50-cloud-init.yaml"
+        }
+        self.renderer_configs = {
+            "eni": {"eni_path": self.network_conf_fn["eni"],
+                    "eni_header": debian.ENI_HEADER},
+            "netplan": {"netplan_path": self.network_conf_fn["netplan"],
+                        "netplan_header": debian.ENI_HEADER,
+                        "postcmds": True}
+        }
+
     @property
     def preferred_ntp_clients(self):
         """The preferred ntp client is dependent on the version."""

--- a/cloudinit/sources/DataSourceAzure.py
+++ b/cloudinit/sources/DataSourceAzure.py
@@ -13,7 +13,6 @@ import os
 import os.path
 import re
 from time import time
-from subprocess import call
 from xml.dom import minidom
 import xml.etree.ElementTree as ET
 
@@ -269,11 +268,6 @@ class DataSourceAzure(sources.DataSource):
     dsname = 'Azure'
     _negotiated = False
     _metadata_imds = sources.UNSET
-    process_name = 'dhclient'
-
-    tmpps = os.popen("ps -Af").read()
-    if process_name not in tmpps[:]:
-        call(['/sbin/dhclient', DEFAULT_PRIMARY_NIC])
 
     def __init__(self, sys_cfg, distro, paths):
         sources.DataSource.__init__(self, sys_cfg, distro, paths)

--- a/cloudinit/sources/DataSourceEc2.py
+++ b/cloudinit/sources/DataSourceEc2.py
@@ -10,7 +10,6 @@
 
 import os
 import time
-from subprocess import call
 
 from cloudinit import ec2_utils as ec2
 from cloudinit import log as logging
@@ -27,7 +26,6 @@ SKIP_METADATA_URL_CODES = frozenset([uhelp.NOT_FOUND])
 
 STRICT_ID_PATH = ("datasource", "Ec2", "strict_id")
 STRICT_ID_DEFAULT = "warn"
-DEFAULT_PRIMARY_NIC = 'eth0'
 
 
 class CloudNames(object):
@@ -45,12 +43,6 @@ class CloudNames(object):
 class DataSourceEc2(sources.DataSource):
 
     dsname = 'Ec2'
-    process_name = 'dhclient'
-
-    tmpps = os.popen("ps -Af").read()
-    if process_name not in tmpps[:]:
-        call(['/sbin/dhclient', DEFAULT_PRIMARY_NIC])
-
     # Default metadata urls that will be used if none are provided
     # They will be checked for 'resolveability' and some of the
     # following may be discarded if they do not resolve

--- a/cloudinit/sources/DataSourceGCE.py
+++ b/cloudinit/sources/DataSourceGCE.py
@@ -2,10 +2,8 @@
 #
 # This file is part of cloud-init. See LICENSE file for license information.
 
-import os
 import datetime
 import json
-from subprocess import call
 
 from base64 import b64decode
 
@@ -20,7 +18,6 @@ LOG = logging.getLogger(__name__)
 MD_V1_URL = 'http://metadata.google.internal/computeMetadata/v1/'
 BUILTIN_DS_CONFIG = {'metadata_url': MD_V1_URL}
 REQUIRED_FIELDS = ('instance-id', 'availability-zone', 'local-hostname')
-DEFAULT_PRIMARY_NIC = 'eth0'
 
 
 class GoogleMetadataFetcher(object):
@@ -53,11 +50,6 @@ class GoogleMetadataFetcher(object):
 class DataSourceGCE(sources.DataSource):
 
     dsname = 'GCE'
-    process_name = 'dhclient'
-
-    tmpps = os.popen("ps -Af").read()
-    if process_name not in tmpps[:]:
-        call(['/sbin/dhclient', DEFAULT_PRIMARY_NIC])
 
     def __init__(self, sys_cfg, distro, paths):
         sources.DataSource.__init__(self, sys_cfg, distro, paths)


### PR DESCRIPTION
After the commit 377d1bb dhclient should be run by Cloud-init properly even without calls from datasources, if this is necessary.
This change solves the problems caused by always active dhclient on eth0 interface when Ec2, GCE, or Azure datasource is used.