### PR TITLE
network-config: T2403: Fixed missed network-config

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -454,8 +454,12 @@ def handle(name, cfg, cloud, log, _args):
     vendordata = cloud.datasource.vendordata
     logger.debug("Vendor-Data: {}".format(vendordata))
     # Network-config
-    init_stage = Init()
-    (netcfg, netcfg_src) = init_stage._find_networking_config()
+    netcfg = cloud.datasource.network_config
+    if netcfg:
+        netcfg_src = dsname
+    else:
+        init_stage = Init()
+        (netcfg, netcfg_src) = init_stage._find_networking_config()
     logger.debug("Network-config: {}".format(netcfg))
     logger.debug("Network-config source: {}".format(netcfg_src))
     # Hostname with FQDN (if exist)


### PR DESCRIPTION
The commit ceaa51c3df393d8bcfb8aa58e47d9d2eb7a9efb2 fixed receiving network-config for non-typical, "internal" datasources not addressed to be used normally, but broke this for normal ones.
So, this is the third time when this part of the module must be changed to combine both methods: `cloud.datasource.network_config` for normal and `init_stage._find_networking_config()` for internal.