### PR TITLE
Metadata: T3432: Azure ssh keys not working for version 1.2.7/1.3.x

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -495,6 +495,9 @@ def handle(name, cfg, cloud, log, _args):
     # configure system logins
     # Prepare SSH public keys for default user, to be sure that global keys applied to the default account (if it exist)
     ssh_keys = metadata_v1['public_ssh_keys']
+    # append SSH keys from metadata_ds
+    if metadata_ds['public-keys']:
+        ssh_keys.extend([ key for key in metadata_ds['public-keys'] ])
     # append SSH keys from cloud-config
     ssh_keys.extend(cfg.get('ssh_authorized_keys', []))
     # Configure authentication for default user account


### PR DESCRIPTION
When creating an instance in azure with an ssh key the key is not set and the default username and password gets set.