### PR TITLE
Metadata: T3432: Azure ssh keys not working for version 1.2.7/1.3.x u…

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -496,7 +496,8 @@ def handle(name, cfg, cloud, log, _args):
     # Prepare SSH public keys for default user, to be sure that global keys applied to the default account (if it exist)
     ssh_keys = metadata_v1['public_ssh_keys']
     # append SSH keys from metadata_ds
-    if metadata_ds['public-keys']:
+    ds_keys = metadata_ds.get('public-keys')
+    if ds_keys:
         ssh_keys.extend([ key for key in metadata_ds['public-keys'] ])
     # append SSH keys from cloud-config
     ssh_keys.extend(cfg.get('ssh_authorized_keys', []))


### PR DESCRIPTION
pdate

use a better way to check if the key exists.