### PR TITLE
Azure: T3432: Reverted changes for appending public-keys

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -514,10 +514,6 @@ def handle(name, cfg, cloud, log, _args):
     # configure system logins
     # Prepare SSH public keys for default user, to be sure that global keys applied to the default account (if it exist)
     ssh_keys = metadata_v1['public_ssh_keys']
-    # append SSH keys from metadata_ds
-    ds_keys = metadata_ds.get('public-keys')
-    if ds_keys:
-        ssh_keys.extend([ key for key in metadata_ds['public-keys'] ])
     # append SSH keys from cloud-config
     ssh_keys.extend(cfg.get('ssh_authorized_keys', []))
     # Configure authentication for default user account


### PR DESCRIPTION
This commit reverts the 5b47d9dc1cd80e3dbd0fb21125febab2e99d5f9c and 57e53d13ad772a74f55c38d95f6d61623fe08633 since Cloud-init 20.4 is not affected by the problem.