### PR TITLE
User-Data: T3735: Fixed "multi" nodes type search

### DIFF
--- a/cloudinit/config/cc_vyos_userdata.py
+++ b/cloudinit/config/cc_vyos_userdata.py
@@ -57,7 +57,7 @@ def get_multi_nodes():
         # search for node.def files
         node_def_files = Path(TEMPLATES_DIR).rglob('node.def')
         # prepare filter to match multi node files
-        regex_filter = re.compile(r'^multi:$', re.MULTILINE)
+        regex_filter = re.compile(r'^multi:.*$', re.MULTILINE)
         # add each node.def with multi mark to list
         for node_def_file in node_def_files:
             file_content = node_def_file.read_text()


### PR DESCRIPTION
Several nodes with "multi" type contain extra space character after the `multi:` mark, which prevents the `cc_vyos_userdata` module to detect their type properly. This commit changes the regex used for detecting such nodes to fix the problem.