### PR TITLE
T4407: Applied workaround for network-config v2

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -502,6 +502,12 @@ def handle(name, cfg, cloud, log, _args):
     else:
         init_stage = Init()
         (netcfg, netcfg_src) = init_stage._find_networking_config()
+    # Depending on Network-config version (and maybe something else)
+    # Cloud-init may provide output here in different formats. That
+    # is why we need to add this additional validation and conversion
+    # to what we expect to see in the end. Most likely, the reason is
+    # in: https://bugs.launchpad.net/cloud-init/+bug/1906187
+    netcfg = netcfg.get('network', netcfg)
     logger.debug("Network-config: {}".format(netcfg))
     logger.debug("Network-config source: {}".format(netcfg_src))
     # Hostname with FQDN (if exist)


### PR DESCRIPTION
Network-config v2 is broken is upstream. See the bug report for details: https://bugs.launchpad.net/cloud-init/+bug/1906187

This workaround allows us to use it again in our module.

An example of a network-config dictionary that we have without the fix:
```
{
	'network': {
		'bonds': {
			'bond2': {
				'interfaces': ['eth2', 'eth3'],
				'parameters': {
					'ad-select': 'bandwidth',
					'all-slaves-active': False,
					'arp-all-targets': 'any',
					'arp-interval': 5,
					'arp-ip-targets': ['1.1.1.1',
						'2.2.2.2'
					],
					'arp-validate': 'active',
					'lacp-rate': 'slow',
					'mii-monitor-interval': 10,
					'min-links': 1,
					'mode': 'active-backup',
					'transmit-hash-policy': 'layer3+4'
				}
			}
		},
		'bridges': {
			'br0': {
				'dhcp4': True,
				'interfaces': ['eth4', 'eth5']
			}
		},
		'ethernets': {
			'eth0': {
				'dhcp4': True,
				'nameservers': {
					'addresses': ['8.8.8.8'],
					'search': ['foo.local',
						'bar.local'
					]
				}
			},
			'eth1': {
				'addresses': ['192.168.14.2/24',
					'2001:1::1/64'
				],
				'gateway4': '192.168.14.1',
				'gateway6': '2001:1::2',
				'nameservers': {
					'addresses': ['8.8.8.8'],
					'search': ['foo.local',
						'bar.local'
					]
				},
				'routes': [{
					'metric': 3,
					'to': '192.0.2.0/24',
					'via': '11.0.0.1'
				}]
			}
		},
		'version': 2,
		'vlans': {
			'vlan100': {
				'dhcp4': True,
				'id': 100,
				'link': 'eth4'
			}
		}
	}
}
```
However, we expect to see only the value of the network key.