### PR TITLE
Hard code VLAN ID to 0 in set_config_ovf

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -141,13 +141,13 @@ def set_config_ovf(config, ovf_environment):
     if ip_address and ip_mask and gateway:
         ip_address_cidr = ipaddress.ip_interface("{}/{}".format(ip_address, ip_mask.replace('/', ''))).with_prefixlen
         logger.debug("Configuring the IP address on the eth0 interface: {}".format(ip_address_cidr))
-        set_ipaddress(config, 'ethernet', 'eth0', ip_address_cidr)
+        set_ipaddress(config, 'ethernet', 'eth0', ip_address_cidr, 0)
 
         logger.debug("Configuring default route via: {}".format(gateway))
         set_ip_route(config, 4, '0.0.0.0/0', gateway, True)
     else:
         logger.debug("Configuring a DHCP client on the eth0 interface (fallback from OVF)")
-        set_ipaddress(config, 'ethernet', 'eth0', 'dhcp')
+        set_ipaddress(config, 'ethernet', 'eth0', 'dhcp', 0)
 
     # Configure DNS servers
     if dns_string:


### PR DESCRIPTION
set_ipaddress was updated to require a VLAN ID parameter in a recent change. set_config_ovf was not updated to reflect the change and it causes cc_vyos.py to fail when booting up a virtual machine created from an OVF template. This change hard codes VLAN ID to 0 to fix the problem for now.

## Proposed Commit Message
```
set_ipaddress was updated to require a VLAN ID parameter in a recent change. set_config_ovf was not updated to reflect the change and it causes cc_vyos.py to fail when booting up a virtual machine created from an OVF template. This change hard codes VLAN ID to 0 to fix the problem for now.
```


## Test Steps
- create virtual machine from ovf template
- check for this error message in /var/log/cloud-init.log
```
2022-12-17 10:45:55,505 - util.py[WARNING]: Running module vyos (<module 'cloudinit.config.cc_vyos' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_vyos.py'>) failed
2022-12-17 10:45:55,505 - util.py[DEBUG]: Running module vyos (<module 'cloudinit.config.cc_vyos' from '/usr/lib/python3/dist-packages/cloudinit/config/cc_vyos.py'>) failed
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/cloudinit/stages.py", line 1086, in _run_modules                                                                        ran, _r = cc.run(
  File "/usr/lib/python3/dist-packages/cloudinit/cloud.py", line 55, in run
    return self._runners.run(name, functor, args, freq, clear_on_fail)
  File "/usr/lib/python3/dist-packages/cloudinit/helpers.py", line 185, in run                                                                                 results = functor(*args)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_vyos.py", line 1076, in handle                                                                      set_config_ovf(config, ovf_environment)
  File "/usr/lib/python3/dist-packages/cloudinit/config/cc_vyos.py", line 150, in set_config_ovf                                                               set_ipaddress(config, 'ethernet', 'eth0', 'dhcp')
TypeError: set_ipaddress() missing 1 required positional argument: 'vlan_id'  
```

## Checklist:
 - [ X] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ - ] I have updated or added any unit tests accordingly
 - [ - ] I have updated or added any documentation accordingly
