### PR TITLE
network-config: T4954: Fixed DNS settings

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -438,6 +438,10 @@ def set_config_interfaces_v1(config, iface_config: dict):
 
     # configure nameservers
     if iface_config['type'] == 'nameserver':
+        # convert a string to list with a single item if necessary
+        if isinstance(iface_config['address'], str):
+            iface_config['address'] = [iface_config['address']]
+
         for item in iface_config['address']:
             set_name_server(config, item)
 


### PR DESCRIPTION
This commit fixes setting DNS configuration if it was presented as a string instead array of strings.

Since the real format of the variable is not well defined and seems to be unstable, depending on the data source, it is better to have this workaround.