### PR TITLE
network-config: T4954: Fixed DNS settings

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -323,6 +323,10 @@ def set_config_interfaces_v1(config, iface_config):
 
     # configure nameservers
     if iface_config['type'] == 'nameserver':
+        # convert a string to list with a single item if necessary
+        if isinstance(iface_config['address'], str):
+            iface_config['address'] = [iface_config['address']]
+
         for item in iface_config['address']:
             logger.debug("Configuring DNS nameserver: {}".format(item))
             config.set(['system', 'name-server'], value=item, replace=False)


### PR DESCRIPTION
This commit fixes setting DNS configuration if it was presented as a string instead array of strings.

Backport of the https://github.com/vyos/vyos-cloud-init/commit/b3812dff44916393c74cba2f2b3e68990d3912df