### PR TITLE
network: T5012: Added a new option for network-config control

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -1089,8 +1089,16 @@ def handle(name, cfg, cloud, log, _args):
             hostname = None
         network_configured = True
 
+    # get network-config control options
+    network_config_global: str = get_cfg_by_path(cfg, 'network/config', '')
+    network_config_vyos: str = get_cfg_by_path(
+        cfg, 'vyos_config_options/network_config', network_config_global)
+    if network_config_vyos == 'disabled':
+        logger.debug("Network-config is disabled (global/vyos): {}/{}".format(
+            network_config_global, network_config_vyos))
+
     # process networking configuration data
-    if netcfg and network_configured is False:
+    if netcfg and network_configured is False and network_config_vyos != 'disabled':
         # check which one version of config we have
         # version 1
         if netcfg['version'] == 1:


### PR DESCRIPTION
A new option for Cloud-Init was added:

```
vyos_config_options:
  network_config: <disabled/enabled>
```

Possible values:

* by default - equal to the `network['config']` from the active Cloud-Init configuration
* `enabled` - configure networking, even if global `network['config']` is set to `disabled`
* `disabled` - do not configure networking, regardless of global `network['config']` value