### PR TITLE
vyos_install: T5220: Fixes for unattended installation

### DIFF
--- a/cloudinit/config/cc_vyos_install.py
+++ b/cloudinit/config/cc_vyos_install.py
@@ -307,7 +307,6 @@ def handle(name: str, cfg: dict, cloud: Cloud, _: Logger, args: list) -> None:
     for dev_type in ['nvme', 'mmcblk']:
         if dev_type in install_target:
             part_prefix = 'p'
-    install_target, target_size = find_disk()
     LOG.info(
         f'system will be installed to {install_target} ({target_size} bytes)')
 

--- a/cloudinit/config/cc_vyos_install.py
+++ b/cloudinit/config/cc_vyos_install.py
@@ -264,23 +264,23 @@ def grub_configure(grub_dir: str, vyos_version: str,
     terminal_input --append serial console
 
     menuentry "VyOS { vyos_version } (KVM console)" {{
-    linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=tty0
-    initrd /boot/{ vyos_version }/initrd.img
+        linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=tty0
+        initrd /boot/{ vyos_version }/initrd.img
     }}
 
     menuentry "VyOS { vyos_version } (Serial console)" {{
-    linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=ttyS{boot_params['serial_console_num']},{boot_params['serial_console_speed']}
-    initrd /boot/{ vyos_version }/initrd.img
+        linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=ttyS{boot_params['serial_console_num']},{boot_params['serial_console_speed']}
+        initrd /boot/{ vyos_version }/initrd.img
     }}
 
     menuentry "VyOS { vyos_version } - password reset (KVM console)" {{
-    linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
-    initrd /boot/{ vyos_version }/initrd.img
+        linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=tty0 init=/opt/vyatta/sbin/standalone_root_pw_reset
+        initrd /boot/{ vyos_version }/initrd.img
     }}
 
     menuentry "VyOS { vyos_version } - password reset (Serial console)" {{
-    linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=ttyS{boot_params['serial_console_num']},{boot_params['serial_console_speed']} init=/opt/vyatta/sbin/standalone_root_pw_reset
-    initrd /boot/{ vyos_version }/initrd.img
+        linux /boot/{ vyos_version }/vmlinuz boot=live rootdelay=5 noautologin net.ifnames=0 biosdevname=0 vyos-union=/boot/{ vyos_version } console=ttyS{boot_params['serial_console_num']},{boot_params['serial_console_speed']} init=/opt/vyatta/sbin/standalone_root_pw_reset
+        initrd /boot/{ vyos_version }/initrd.img
     }}
     ''')
 

--- a/cloudinit/config/cc_vyos_install.py
+++ b/cloudinit/config/cc_vyos_install.py
@@ -340,13 +340,13 @@ def handle(name: str, cfg: dict, cloud: Cloud, _: Logger, args: list) -> None:
         f'partiton {install_target}{part_prefix}2 mouted to {DIR_DST_ROOT}/boot/efi'
     )
 
+    # copy config
     # a config dir. It is the deepest one, so the comand will
     # create all the rest in a single step
-    target_config_dir: str = f'{DIR_DST_ROOT}/boot/{image_name}/rw/opt/vyatta/etc/config/'
+    target_config_dir: str = f'{DIR_DST_ROOT}/boot/{image_name}/rw/opt/vyatta/etc/'
     Path(target_config_dir).mkdir(parents=True)
-    # copy config
-    copy('/opt/vyatta/etc/config/config.boot', target_config_dir)
-    Path(f'{target_config_dir}/.vyatta_config').touch()
+    # we must use Linux cp command, because Python cannot preserve ownership
+    run(['cp', '-pr', '/opt/vyatta/etc/config', target_config_dir])
     LOG.info('configuration copied from running system')
 
     # create a persistence.conf

--- a/config/cloud.cfg.d/20_vyos_install.cfg
+++ b/config/cloud.cfg.d/20_vyos_install.cfg
@@ -8,3 +8,4 @@
 #     console_type: serial # type of console: kvm, serial. Default: kvm
 #     serial_console_num: 1 # serial console number. Default: 0
 #     serial_console_speed: 115200 # serial console speed. Default: 9600
+#     cmdline_extra: nosmt mitigations=off # add extra parameters for kernel cmdline


### PR DESCRIPTION
This PR contains three minor but important fixes:

- changed the template for `grub.cfg` - CLI `show system image` command was not able to parse the old one properly.
- copy the whole `/config` folder, not only `/config/config.boot` during installation. Highly useful for cases when we want to provide any other config material, except CLI commands.
- cosmetic fix with removed excessive code.
- added a new option to control kernel cmdline.