### PR TITLE
fix to handle OpenStack where mtu exists but is null

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -466,7 +466,7 @@ def set_config_interfaces_v1(config, iface_config: dict):
             config.set_tag(['interfaces', 'ethernet'])
 
         # configre MTU
-        if 'mtu' in iface_config:
+        if 'mtu' in iface_config and iface_config['mtu'] is not None:
             set_ether_mtu(config, iface_name, iface_config['mtu'])
         # We still need to set default MTU for Ethernet, for compatibility reasons
         else:


### PR DESCRIPTION
## Proposed Commit Message

This handles a bug where cloud-init crashes on OpenStack due to mtu being returned as null.

```
summary: 

OpenStack metadata currently returns mtu as part of the interface settings but with a value of null.

An example of this can be seen over here - https://docs.openstack.org/nova/latest/user/metadata.html

For this command `curl http://169.254.169.254/openstack/2018-08-27/network_data.json`

I am getting

```
{
  "links": [
    {
      "id": "tap99d5c148-2f",
      "vif_id": "99d5c148-2fe5-460c-ae86-c7e437b548eb",
      "type": "ovs",
      "mtu": null,
      "ethernet_mac_address": "fa:16:3e:cb:bb:d0"
    }
  ],
  "networks": [
    {
      "id": "network0",
      "type": "ipv4_dhcp",
      "link": "tap99d5c148-2f",
      "network_id": "84b98fe2-039e-4b47-93c2-8e795fe983c5"
    }
  ],
  "services": [
    {
      "type": "dns",
      "address": "8.8.8.7"
    },
    {
      "type": "dns",
      "address": "8.8.8.8"
    }
  ]
}
```

This commit checks for null before attempting to access the value 

## Test Steps

The code has been tested on OpenStack and addresses the issue

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [x ] I have updated or added any unit tests accordingly
 - [x ] I have updated or added any documentation accordingly
