### PR TITLE
cc_vyos: T6007: Run config migrations before Cloud-init

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -1081,6 +1081,10 @@ def handle(name, cfg, cloud, log, _args):
         file_name = cfg_file_name
 
     logger.debug("Using configuration file: {}".format(file_name))
+    # We must run all migrations on the config before Cloud-init will modify it
+    # Otherwise, regardless of proper syntax for the current version, migrations will be re-run with unpredictable result
+    logger.debug("Running migrations for: {}".format(file_name))
+    run(['/usr/libexec/vyos/run-config-migration.py', file_name])
     with open(file_name, 'r') as f:
         config_file = f.read()
     config = ConfigTree(config_file)


### PR DESCRIPTION
Configuration in `vyos_config_commands` is expected to use a syntax from the target VyOS version. But, if Cloud-init applies configuration commands to a default file, all the migrations (from the 0 version to the latest) will still be executed on top of it.

This process can break proper config, for example, if the current syntax variant partially repeats one of the older ones, which will trigger a migration without need.