### PR TITLE
SSH KEY: T6568: Fixed adding SSH keys with same comments

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -91,6 +91,11 @@ def set_ssh_login(config, user, key_string):
         logger.info("Generating UUID for an SSH key because a comment is empty or unacceptable by CLI")
         key_parsed.comment = "cloud-init-{}".format(uuid4())
 
+    # check if a key with the same comment already exists
+    if config.exists(['system', 'login', 'user', user, 'authentication', 'public-keys', key_parsed.comment]):
+        logger.debug("Generating UUID for an SSH key because a public key with comment {} already exists for user {}".format(key_parsed.comment, user))
+        key_parsed.comment = "cloud-init-{}".format(uuid4())
+
     config.set(['system', 'login', 'user', user, 'authentication', 'public-keys', key_parsed.comment, 'key'], value=key_parsed.base64, replace=True)
     config.set(['system', 'login', 'user', user, 'authentication', 'public-keys', key_parsed.comment, 'type'], value=key_parsed.keytype, replace=True)
     if key_parsed.options:


### PR DESCRIPTION
If a key with the same comment already exists in a configuration, generate a new ID for a new one.

Example of such a case:

```
ssh-rsa <base64> my_user_name
ssh-ed25519 <base64> my_user_name
```