### PR TITLE
T6674: Add reusable forkflow trigger to build repo package

### DIFF
--- a/.github/workflows/trigger-rebuild-repo-package.yml
+++ b/.github/workflows/trigger-rebuild-repo-package.yml
@@ -1,0 +1,33 @@
+name: Trigger to build a deb package from repo
+
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - current
+  workflow_dispatch:
+
+jobs:
+  get_repo_name:
+    runs-on: ubuntu-latest
+    outputs:
+      PACKAGE_NAME: ${{ steps.package_name.outputs.PACKAGE_NAME }}
+    steps:
+      - name: Set variables
+        id: package_name
+        run: |
+          echo "PACKAGE_NAME=$(basename ${{ github.repository }})" >> $GITHUB_OUTPUT
+
+  trigger-build:
+    needs: get_repo_name
+    uses: vyos/.github/.github/workflows/trigger-rebuild-repo-package.yml@current
+    with:
+        branch: ${{ github.ref_name }}
+        package_name: ${{ needs.get_repo_name.outputs.PACKAGE_NAME }}
+        REF: main # optinal because the default value is main
+    secrets:
+        REMOTE_OWNER: ${{ secrets.REMOTE_OWNER }}
+        REMOTE_REUSE_REPO: ${{ secrets.REMOTE_REUSE_REPO }}
+        GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
+        PAT: ${{ secrets.PAT }}


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->
Add reusable forkflow trigger to re-build repo package

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
