### PR TITLE
CI: T7579: fix of the run trigger for CLA

### DIFF
--- a/.github/workflows/cla-check.yml
+++ b/.github/workflows/cla-check.yml
@@ -7,7 +7,7 @@ permissions:
   statuses: write
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, closed]
   issue_comment:
     types: [created]
@@ -15,5 +15,4 @@ on:
 jobs:
   call-cla-assistant:
     uses: vyos/vyos-cla-signatures/.github/workflows/cla-reusable.yml@current
-    secrets:
-      CLA_PAT: ${{ secrets.CLA_PAT }}
+    secrets: inherit


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
The current implementation of the CLA has an issue when the CLA check workflow fails due to insufficient access to the necessary GA secret. This problem arises from an incorrect run trigger `pull_request`, which needs to be replaced with the appropriate trigger `pull_request_target`.

```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
