### PR TITLE
feat(T7206): Fix vyos default config path

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -1047,7 +1047,7 @@ def handle(name, cfg, cloud, log, _args):
 
     # VyOS configuration file selection
     cfg_file_name = '/opt/vyatta/etc/config/config.boot'
-    bak_file_name = '/opt/vyatta/etc/config.boot.default'
+    bak_file_name = '/usr/share/vyos/config.boot.default'
 
     # open configuration file
     if not Path(cfg_file_name).exists():

--- a/cloudinit/config/cc_vyos_userdata.py
+++ b/cloudinit/config/cc_vyos_userdata.py
@@ -32,7 +32,7 @@ frequency = PER_INSTANCE
 TEMPLATES_DIR = '/opt/vyatta/share/vyatta-cfg/templates/'
 # VyOS configuration files
 CFG_FILE_MAIN = '/opt/vyatta/etc/config/config.boot'
-CFG_FILE_DEFAULT = '/opt/vyatta/etc/config.boot.default'
+CFG_FILE_DEFAULT = '/usr/share/vyos/config.boot.default'
 
 
 # get list of all tag nodes
@@ -209,10 +209,10 @@ def handle(name, cfg, cloud, log, _args):
 
         # save a new configuration file
         try:
-            with open(config_file_path, 'w') as f:
+            with open(CFG_FILE_MAIN, 'w') as f:
                 f.write(config.to_string())
             logger.debug(
-                "Configuration file saved: {}".format(config_file_path))
+                "Configuration file saved: {}".format(CFG_FILE_MAIN))
         except Exception as err:
             logger.error("Failed to write config into the file {}: {}".format(
-                config_file_path, err))
+                CFG_FILE_MAIN, err))


### PR DESCRIPTION
## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
Resolves problem with wrong default config in cloud-init

Check https://vyos.dev/T7206 for mor info.

LP: #T7206
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly


Hi,
I wanted to test this changes, but i don't have idea how to duild this package myself.
Could you provide me instructions how to build it as .deb package?