### PR TITLE
vyos: Fix handling of IPv6 netmasks on OpenStack

### DIFF
--- a/cloudinit/config/cc_vyos.py
+++ b/cloudinit/config/cc_vyos.py
@@ -28,6 +28,7 @@ from uuid import uuid4
 from cloudinit import log as logging
 from cloudinit.ssh_util import AuthKeyLineParser
 from cloudinit.distros import ug_util
+from cloudinit.net.network_state import ipv6_mask_to_net_prefix
 from cloudinit.settings import PER_INSTANCE
 from cloudinit.sources import INSTANCE_JSON_FILE
 from cloudinit.stages import Init
@@ -439,8 +440,12 @@ def _configure_subnets_v1(config,
             # configure routes
             if 'routes' in subnet:
                 for item in subnet['routes']:
+                    if ipaddress.ip_address(item['network']).version == 6:
+                        netmask = ipv6_mask_to_net_prefix(item['netmask'])
+                    else:
+                        netmask = item['netmask']
                     ip_network = ipaddress.ip_network('{}/{}'.format(
-                        item['network'], item['netmask']))
+                        item['network'], netmask))
                     set_ip_route(config, ip_network.version,
                                  ip_network.compressed, item['gateway'], True)
 


### PR DESCRIPTION

## Proposed Commit Message
<!-- Include a proposed commit message because all PRs are squash merged -->

```
On OpenStack with a network with DHCP disabled, IPv6 routes are passed like this:

    'routes': [{'network': '::', 'netmask': '::', 'gateway': '2001:db8::1'}]

This results in a call to ipaddress.ip_network('::/::'), which Python does not regard as valid network notation.

So this commit uses cloudinit.net.network_state.ipv6_mask_to_net_prefix() to calculate the prefix length from that notation.
```

## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [ ] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
