### PR TITLE
general: T8595: add CLAUDE.md

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,1 +1,0 @@
-CLAUDE.md

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../CLAUDE.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 # CLAUDE.md
 
 ## Project purpose
-VyOS-flavored fork of canonical `cloud-init`. Adds VyOS datasource handlers and userdata processors so that VyOS images can self-configure on first boot in cloud environments (AWS, Azure, GCP, OpenStack, etc.).
+VyOS-flavored fork of canonical `cloud-init`. Configures VyOS images on first boot in cloud environments (AWS, Azure, GCP, OpenStack, etc.) using upstream datasource handlers; VyOS-specific datasource and userdata-processor additions are intended future work.
 
 ## Tech stack
 - Python (≥3.x). Upstream `cloud-init` codebase.
@@ -22,10 +22,11 @@ make                                # see in-repo Makefile targets
 - `cloudinit/` — core Python package (datasources, handlers, modules).
 - `config/` — default config files installed under `/etc/cloud/`.
 - `templates/` — Jinja2 templates rendered at boot.
-- `systemd/`, `sysvinit/`, `udev/`, `bash_completion/` — init system glue.
+- `systemd/`, `sysvinit/`, `upstart/`, `udev/`, `bash_completion/` — init system glue.
 - `tests/` — unit + integration tests.
 - `tools/` — helper scripts.
-- `packages/` — packaging templates (Debian, RPM, snap).
+- `packages/` — packaging templates (Debian, RPM/SUSE, bddeb/brpm scripts).
+- `snapcraft.yaml` — snap packaging descriptor (repo root).
 - `doc/` — Sphinx documentation source.
 - `setup.py`, `pyproject.toml`, `tox.ini`, `conftest.py`.
 - Vendored upstream license files: `LICENSE-Apache2.0`, `LICENSE-GPLv3`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,3 @@ Mirror twin: `VyOS-Networks/vyos-cloud-init`. Mirror pipeline status varies — 
 - Keep VyOS-specific changes minimal and clearly delineated to ease upstream merges.
 - After merging a PR, the `trigger-rebuild-repo-package.yml` workflow fires a REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = VyOS-Networks) to rebuild the Debian package as `vyosbot`.
 - Cloud-init's upstream test suite is heavy; running `pytest tests/unittests` is usually sufficient for small VyOS-side patches.
-
----
-
-This file is mirrored on Confluence: [`vyos/vyos-cloud-init`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479480). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,54 @@
+# CLAUDE.md
+
+## Project purpose
+VyOS-flavored fork of canonical `cloud-init`. Adds VyOS datasource handlers and userdata processors so that VyOS images can self-configure on first boot in cloud environments (AWS, Azure, GCP, OpenStack, etc.).
+
+## Tech stack
+- Python (≥3.x). Upstream `cloud-init` codebase.
+- Build: `setup.py` + `pyproject.toml` (black 79-char line length, isort black profile). `Makefile` for common dev tasks.
+- Tests: `tox.ini`, `pytest` via `conftest.py`. Multiple `*-requirements.txt` files (`requirements.txt`, `test-requirements.txt`, `integration-requirements.txt`, `doc-requirements.txt`).
+- Debian packaging in `packages/`.
+
+## Build / test / run
+```
+pip install -r requirements.txt -r test-requirements.txt
+tox                                # full test matrix
+pytest tests/unittests              # unit tests only
+make                                # see in-repo Makefile targets
+# Debian package built indirectly via vyos-build-packages.
+```
+
+## Repository layout
+- `cloudinit/` — core Python package (datasources, handlers, modules).
+- `config/` — default config files installed under `/etc/cloud/`.
+- `templates/` — Jinja2 templates rendered at boot.
+- `systemd/`, `sysvinit/`, `udev/`, `bash_completion/` — init system glue.
+- `tests/` — unit + integration tests.
+- `tools/` — helper scripts.
+- `packages/` — packaging templates (Debian, RPM, snap).
+- `doc/` — Sphinx documentation source.
+- `setup.py`, `pyproject.toml`, `tox.ini`, `conftest.py`.
+- Vendored upstream license files: `LICENSE-Apache2.0`, `LICENSE-GPLv3`.
+
+## Cross-repo context
+- Consumed by `vyos/vyos-build` as one of the 14 source packages in `VyOS-Networks/vyos-build-packages/repos.toml`. Produces the `cloud-init` `.deb` shipped inside the VyOS ISO.
+- Companion to `VyOS-Networks/vyos-walinuxagent` (Azure-specific agent) and `VyOS-Networks/vyos-salt-minion` (SaltStack agent) for cloud-side configuration.
+- VyOS-specific datasources may interact with `vyos-1x` config-tree primitives at runtime.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev). Enforced via inherited reusables.
+- Workflows: `pr-mirror-repo-sync.yml`, `trigger-rebuild-repo-package.yml`, `cla-check.yml`, `stale.yml` (uses `vyos/.github@current` reusables).
+- License: dual Apache-2.0 / GPL-3 (inherited from upstream `cloud-init`).
+- Default branch: `current`. Pull from upstream `canonical/cloud-init` via merge or rebase, preserve VyOS-specific deltas.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-cloud-init`. Mirror pipeline status varies — treat the `vyos/*` side as canonical. The VyOS-Networks twin's default branch is reportedly `git-actions` (workflow-experiment branch); do not rely on it for code state.
+
+## Notes for future contributors
+- Keep VyOS-specific changes minimal and clearly delineated to ease upstream merges.
+- After merging a PR, the `trigger-rebuild-repo-package.yml` workflow fires a REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = VyOS-Networks) to rebuild the Debian package as `vyosbot`.
+- Cloud-init's upstream test suite is heavy; running `pytest tests/unittests` is usually sufficient for small VyOS-side patches.
+
+---
+
+This file is mirrored on Confluence: [`vyos/vyos-cloud-init`](https://internal.confluence.vyos.com/wiki/spaces/VYOS/pages/818479480). The Confluence page also carries the per-repo audit data (settings, workflows, secret counts, hygiene) that complements this CLAUDE.md. Edit either side; resync via the documentation pipeline.


### PR DESCRIPTION
## Summary

Adds a single source of truth for repo-level agent instructions, plus three symlinks so different agentic tools all read the same content from one canonical file.

**Files added:**

| Path | Type | Consumed by |
|---|---|---|
| `CLAUDE.md` | real file | Claude Code, Anthropic agents |
| `AGENTS.md` | symlink → `CLAUDE.md` | tools that follow the AGENTS.md convention (e.g. OpenAI Codex) |
| `.cursorrules` | symlink → `CLAUDE.md` | Cursor |
| `.github/copilot-instructions.md` | symlink → `../CLAUDE.md` | GitHub Copilot ([docs](https://docs.github.com/en/copilot/how-tos/configure-custom-instructions-in-your-ide/add-repository-instructions-in-your-ide)) |

**Rationale**

- One source of truth — guidance lives in `CLAUDE.md`, the symlinks are zero-content. No drift between four files.
- Each agentic tool reads its canonical filename and gets the same content.
- Mac/Linux dev environments handle symlinks natively. Windows checkouts may render them as text files containing the target path; the canonical `CLAUDE.md` is unaffected and still rendered/served correctly by GitHub.

**Out of scope**

Path-specific Copilot instructions (`.github/instructions/*.instructions.md`) need YAML frontmatter (`applyTo:`) and target specific globs, so they cannot be symlinks. Not added here; they can be authored as separate small files per-repo if/when narrow path-scoped guidance is needed.

Tracked under [T8595](https://vyos.dev/T8595).

## Test plan

- [ ] `CLAUDE.md` renders on GitHub.
- [ ] `AGENTS.md`, `.cursorrules`, `.github/copilot-instructions.md` resolve to CLAUDE.md content (`readlink` returns the right target).
- [ ] CI passes.

🤖 Generated by [robots](https://vyos.io)
