### PR TITLE
general: T8595: add AGENTS.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,1 @@
+../AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,8 @@ make                                # see in-repo Makefile targets
 - Vendored upstream license files: `LICENSE-Apache2.0`, `LICENSE-GPLv3`.
 
 ## Cross-repo context
-- Consumed by `vyos/vyos-build` as one of the 14 source packages in `VyOS-Networks/vyos-build-packages/repos.toml`. Produces the `cloud-init` `.deb` shipped inside the VyOS ISO.
-- Companion to `VyOS-Networks/vyos-walinuxagent` (Azure-specific agent) and `VyOS-Networks/vyos-salt-minion` (SaltStack agent) for cloud-side configuration.
+- Consumed by `vyos/vyos-build` as one of the 14 source packages in an internal repository. Produces the `cloud-init` `.deb` shipped inside the VyOS ISO.
+- Companion to an internal repository (Azure-specific agent) and an internal repository (SaltStack agent) for cloud-side configuration.
 - VyOS-specific datasources may interact with `vyos-1x` config-tree primitives at runtime.
 
 ## Conventions
@@ -42,10 +42,7 @@ make                                # see in-repo Makefile targets
 - License: dual Apache-2.0 / GPL-3 (inherited from upstream `cloud-init`).
 - Default branch: `current`. Pull from upstream `canonical/cloud-init` via merge or rebase, preserve VyOS-specific deltas.
 
-## Mirror relationship
-Mirror twin: `VyOS-Networks/vyos-cloud-init`. Mirror pipeline status varies — treat the `vyos/*` side as canonical. The VyOS-Networks twin's default branch is reportedly `git-actions` (workflow-experiment branch); do not rely on it for code state.
-
 ## Notes for future contributors
 - Keep VyOS-specific changes minimal and clearly delineated to ease upstream merges.
-- After merging a PR, the `trigger-rebuild-repo-package.yml` workflow fires a REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = VyOS-Networks) to rebuild the Debian package as `vyosbot`.
+- After merging a PR, the `trigger-rebuild-repo-package.yml` workflow fires a REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = the private side) to rebuild the Debian package as `vyosbot`.
 - Cloud-init's upstream test suite is heavy; running `pytest tests/unittests` is usually sufficient for small VyOS-side patches.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project purpose
-VyOS-flavored fork of canonical `cloud-init`. Configures VyOS images on first boot in cloud environments (AWS, Azure, GCP, OpenStack, etc.) using upstream datasource handlers; VyOS-specific datasource and userdata-processor additions are intended future work.
+VyOS-flavored fork of canonical `cloud-init`. Configures VyOS images on first boot in cloud environments (AWS, Azure, GCP, OpenStack, etc.) using upstream datasource handlers.
 
 ## Tech stack
 - Python (≥3.x). Upstream `cloud-init` codebase.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md
+
+## Project purpose
+VyOS-flavored fork of canonical `cloud-init`. Configures VyOS images on first boot in cloud environments (AWS, Azure, GCP, OpenStack, etc.) using upstream datasource handlers; VyOS-specific datasource and userdata-processor additions are intended future work.
+
+## Tech stack
+- Python (≥3.x). Upstream `cloud-init` codebase.
+- Build: `setup.py` + `pyproject.toml` (black 79-char line length, isort black profile). `Makefile` for common dev tasks.
+- Tests: `tox.ini`, `pytest` via `conftest.py`. Multiple `*-requirements.txt` files (`requirements.txt`, `test-requirements.txt`, `integration-requirements.txt`, `doc-requirements.txt`).
+- Debian packaging in `packages/`.
+
+## Build / test / run
+```
+pip install -r requirements.txt -r test-requirements.txt
+tox                                # full test matrix
+pytest tests/unittests              # unit tests only
+make                                # see in-repo Makefile targets
+# Debian package built indirectly via vyos-build-packages.
+```
+
+## Repository layout
+- `cloudinit/` — core Python package (datasources, handlers, modules).
+- `config/` — default config files installed under `/etc/cloud/`.
+- `templates/` — Jinja2 templates rendered at boot.
+- `systemd/`, `sysvinit/`, `upstart/`, `udev/`, `bash_completion/` — init system glue.
+- `tests/` — unit + integration tests.
+- `tools/` — helper scripts.
+- `packages/` — packaging templates (Debian, RPM/SUSE, bddeb/brpm scripts).
+- `snapcraft.yaml` — snap packaging descriptor (repo root).
+- `doc/` — Sphinx documentation source.
+- `setup.py`, `pyproject.toml`, `tox.ini`, `conftest.py`.
+- Vendored upstream license files: `LICENSE-Apache2.0`, `LICENSE-GPLv3`.
+
+## Cross-repo context
+- Consumed by `vyos/vyos-build` as one of the 14 source packages in `VyOS-Networks/vyos-build-packages/repos.toml`. Produces the `cloud-init` `.deb` shipped inside the VyOS ISO.
+- Companion to `VyOS-Networks/vyos-walinuxagent` (Azure-specific agent) and `VyOS-Networks/vyos-salt-minion` (SaltStack agent) for cloud-side configuration.
+- VyOS-specific datasources may interact with `vyos-1x` config-tree primitives at runtime.
+
+## Conventions
+- Commit/PR title: `component: T12345: description` (Phorge task ID at https://vyos.dev). Enforced via inherited reusables.
+- Workflows: `pr-mirror-repo-sync.yml`, `trigger-rebuild-repo-package.yml`, `cla-check.yml`, `stale.yml` (uses `vyos/.github@current` reusables).
+- License: dual Apache-2.0 / GPL-3 (inherited from upstream `cloud-init`).
+- Default branch: `current`. Pull from upstream `canonical/cloud-init` via merge or rebase, preserve VyOS-specific deltas.
+
+## Mirror relationship
+Mirror twin: `VyOS-Networks/vyos-cloud-init`. Mirror pipeline status varies — treat the `vyos/*` side as canonical. The VyOS-Networks twin's default branch is reportedly `git-actions` (workflow-experiment branch); do not rely on it for code state.
+
+## Notes for future contributors
+- Keep VyOS-specific changes minimal and clearly delineated to ease upstream merges.
+- After merging a PR, the `trigger-rebuild-repo-package.yml` workflow fires a REST `workflow_dispatch` into `$REMOTE_OWNER/vyos-build-packages` (REMOTE_OWNER = VyOS-Networks) to rebuild the Debian package as `vyosbot`.
+- Cloud-init's upstream test suite is heavy; running `pytest tests/unittests` is usually sufficient for small VyOS-side patches.


### PR DESCRIPTION
Adds `AGENTS.md` (tool-neutral primary instructions) at repo root and a symlink `.github/copilot-instructions.md` → `../AGENTS.md` for Copilot code review compatibility.

Schema rationale and full spec: [T8595](https://vyos.dev/T8595).

**Why this shape:** Cursor 0.50+, Claude Code, OpenAI Codex, and Copilot Coding Agent / Chat / CLI read `AGENTS.md` natively. Copilot **code review** is the single tool that doesn't (per [GitHub's docs](https://docs.github.com/en/copilot/reference/custom-instructions-support)) — the symlink is the workaround until [community/discussions/174058](https://github.com/orgs/community/discussions/174058) lands. Replaces the previous `CLAUDE.md`-only schema PR for this repo.
