### PR TITLE
T8876: Update stale PR workflow with permissions and org restriction

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,11 +4,15 @@ on:
   schedule:
   - cron: "0 0 * * *"  # Daily @ 00:00
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   stale:
 
     runs-on: ubuntu-latest
-
+    if: github.repository_owner == 'vyos'
     steps:
     - uses: actions/stale@v10
       with:


### PR DESCRIPTION
Updated the existing stale PR workflow to include required permissions and restrict execution to the intended organization.

Changes:

Added permissions:
pull-requests: write
contents: read
Added condition to run job only for vyos org:
if: github.repository_owner == 'vyos'

Why:

Ensures the workflow has the required access to manage PRs
Prevents execution in forks or non-org repositories

Impact:

No functional change to stale logic
Improves security and control over workflow execution


## Additional Context
<!-- If relevant -->

## Test Steps
<!-- Please include any steps necessary to verify (and reproduce if
this is a bug fix) this change on a live deployed system,
including any necessary configuration files, user-data,
setup, and teardown. Scripts used may be attached directly to this PR. -->

## Checklist:
<!-- Go over all the following points, and put an `x` in all the boxes
that apply. -->
 - [x] My code follows the process laid out in [the documentation](https://cloudinit.readthedocs.io/en/latest/topics/contributing.html)
 - [ ] I have updated or added any unit tests accordingly
 - [ ] I have updated or added any documentation accordingly
